### PR TITLE
Support build from docker

### DIFF
--- a/nodemanager/README.md
+++ b/nodemanager/README.md
@@ -1,5 +1,6 @@
 ## Compiling and Dependencies
 
+### Compile from source code
 The code is compiled on Ubuntu(16.04) with the following dependencies:
 
 * [Boost](https://www.boost.org/) - can be installed by package libboost-all-dev(1.58)
@@ -7,6 +8,9 @@ The code is compiled on Ubuntu(16.04) with the following dependencies:
 * [spdlog](https://github.com/gabime/spdlog) - only header files in the `include` dir. Just clone the branch `v1.x` from GitHub. Note that the package libspdlog-dev(1.6-1) is too old to use.
 
 Depending on where the spdlog headers are put, you may need to modify makefile to modify path for spdlog headers.
+
+### Compile from docker image
+We offer an image to help build artifacts. You can build and get artifacts by running the script `./build_and_get_artifact.sh`.
 
 ## Conding Convention
 

--- a/nodemanager/build_and_get_artifact.sh
+++ b/nodemanager/build_and_get_artifact.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "Start to build from image aaronyll/nodemanager_build_1804"
+docker run -it aaronyll/nodemanager_build_1804
+echo "Start to copy artifacts to ./hpcnodemanager-latest"
+docker cp $(docker ps -qa | head -n 1):/hpcpack-linux-agent/nodemanager/bin/release ./hpcnodemanager-latest
+tput setaf 2
+echo "Done."


### PR DESCRIPTION
- Add `Compiling and Dependencies/Compile from docker image` in README.
- Add `build_and_get_artifact.sh` to automate build and get artifacts.