### PR TITLE
fix race condition when get stale request to StartTask

### DIFF
--- a/nodemanager/data/TaskInfo.h
+++ b/nodemanager/data/TaskInfo.h
@@ -56,17 +56,27 @@ namespace hpc
                 void SetTaskRequeueCount(int c)
                 {
                     int oldC = this->taskRequeueCount;
-                    this->taskRequeueCount = c;
 
-                    if (!this->processKeySet)
+                    if (c < oldC)
                     {
-                        this->ProcessKey = this->GetAttemptId();
-                        this->processKeySet = true;
+                        hpc::utils::Logger::Warn(this->JobId, this->TaskId, this->taskRequeueCount,
+                                                 "The requeue count must be monotonically increasing, cannot change requeue count from {0} to {1}",
+                                                 oldC, c);
                     }
+                    else
+                    {
+                        this->taskRequeueCount = c;
 
-                    hpc::utils::Logger::Info(this->JobId, this->TaskId, this->taskRequeueCount,
-                        "Change requeue count from {0} to {1}, processKey {2}",
-                        oldC, c, this->ProcessKey);
+                        if (!this->processKeySet)
+                        {
+                            this->ProcessKey = this->GetAttemptId();
+                            this->processKeySet = true;
+                        }
+
+                        hpc::utils::Logger::Info(this->JobId, this->TaskId, this->taskRequeueCount,
+                                                 "Change requeue count from {0} to {1}, processKey {2}",
+                                                 oldC, c, this->ProcessKey);
+                    }
                 }
 
                 int GetProcessCount() const { return this->ProcessIds.size(); }


### PR DESCRIPTION
This branch fixes a bug that may cause the mismatch between `nodemanager` and `headnode`.

# Background
By design, if the headnode loses heartbeat with nodemanager after scheduling a task, it will add taskRequeueCount then reschedule the task with new count. In this condition, the task is only completed when headnode gets a response from nodemanager with the new count.

At the same time on the nodemanager side, the stale task still request in, and then changes taskRequeueCount to older count when construct the response to headnode, so the count mismatch between response and headnode, which caused the task failed to complete and eventually timeout.